### PR TITLE
String.Empty bug URL during plugin HttpClient load & multiple shipment offerings not getting filtered out

### DIFF
--- a/Nop.Plugin.Shipping.USPS/Services/USPSHttpClient.cs
+++ b/Nop.Plugin.Shipping.USPS/Services/USPSHttpClient.cs
@@ -28,7 +28,7 @@ namespace Nop.Plugin.Shipping.USPS.Services
         public USPSHttpClient(HttpClient client, USPSSettings uspsSettings)
         {
             //configure client
-            client.BaseAddress = new Uri(uspsSettings.Url ?? USPSShippingDefaults.DEFAULT_URL);
+            client.BaseAddress = !string.IsNullOrEmpty(uspsSettings.Url) ? new Uri(uspsSettings.Url) : new Uri(USPSShippingDefaults.DEFAULT_URL);
             client.Timeout = TimeSpan.FromMilliseconds(5000);
             client.DefaultRequestHeaders.Add(HeaderNames.UserAgent, $"nopCommerce-{NopVersion.CurrentVersion}");
             client.DefaultRequestHeaders.Add(HeaderNames.Accept, MimeTypes.ApplicationXml);


### PR DESCRIPTION
It is possible for uspsSettings.Url to be an empty string if settings are saved and the URL field is left blank, but the username and password are set. This breaks the plugin load.