### PR TITLE
implement IShipmentTracker in GetShipmentTrackerAsync()

### DIFF
--- a/Nop.Plugin.Shipping.USPS/USPSComputationMethod.cs
+++ b/Nop.Plugin.Shipping.USPS/USPSComputationMethod.cs
@@ -90,7 +90,7 @@ namespace Nop.Plugin.Shipping.USPS
         /// </returns>
         public Task<IShipmentTracker> GetShipmentTrackerAsync()
         {
-            return Task.FromResult<IShipmentTracker>(null);
+            return Task.FromResult<IShipmentTracker>(new USPSShipmentTracker(_uspsService));
         }
 
         /// <summary>
@@ -158,7 +158,7 @@ namespace Nop.Plugin.Shipping.USPS
         #endregion
 
         #region Properties
-        
+
         /// <summary>
         /// Gets a shipment tracker
         /// </summary>


### PR DESCRIPTION
the shipment tracker is not impemented properly in the GetShipmentTrackerAsync function, therefore, the TrackingNumberUrl message token is not properly rendered. 