### PR TITLE
Remove old method Shipment tracker Property

### DIFF
--- a/Nop.Plugin.Shipping.USPS/USPSComputationMethod.cs
+++ b/Nop.Plugin.Shipping.USPS/USPSComputationMethod.cs
@@ -44,7 +44,6 @@ namespace Nop.Plugin.Shipping.USPS
         }
 
         #endregion
-
         #region Methods
 
         /// <summary>
@@ -154,15 +153,6 @@ namespace Nop.Plugin.Shipping.USPS
 
             await base.UninstallAsync();
         }
-
-        #endregion
-
-        #region Properties
-
-        /// <summary>
-        /// Gets a shipment tracker
-        /// </summary>
-        public IShipmentTracker ShipmentTracker => new USPSShipmentTracker(_uspsService);
 
         #endregion
     }

--- a/Nop.Plugin.Shipping.USPS/USPSComputationMethod.cs
+++ b/Nop.Plugin.Shipping.USPS/USPSComputationMethod.cs
@@ -90,7 +90,7 @@ namespace Nop.Plugin.Shipping.USPS
         /// </returns>
         public Task<IShipmentTracker> GetShipmentTrackerAsync()
         {
-            return Task.FromResult<IShipmentTracker>(null);
+            return Task.FromResult<IShipmentTracker>(new USPSShipmentTracker(_uspsService));
         }
 
         /// <summary>
@@ -158,7 +158,7 @@ namespace Nop.Plugin.Shipping.USPS
         #endregion
 
         #region Properties
-        
+
         /// <summary>
         /// Gets a shipment tracker
         /// </summary>


### PR DESCRIPTION
This property is no longer used and can be removed.